### PR TITLE
Remove internal from FlippableController

### DIFF
--- a/flippable/src/main/java/com/wajahatkarim/flippable/FlippableController.kt
+++ b/flippable/src/main/java/com/wajahatkarim/flippable/FlippableController.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.asSharedFlow
  *
  * @author Wajahat Karim (https://wajahatkarim.com)
  */
-class FlippableController internal constructor() {
+class FlippableController {
 
     private val _flipRequests = MutableSharedFlow<FlippableState>(extraBufferCapacity = 1)
     internal val flipRequests = _flipRequests.asSharedFlow()


### PR DESCRIPTION
Currently, device rotation restores the FlippableState to INITIALIZE. In order to persist state
across device rotation I would like to host the FlippableController in the view model so that
I can manager it there.

Alternatively, it would be nice to be able to implement my own remember where I'm able to provide a key
so that I can update the FlippableController when the key changes.