### PR TITLE
chore: remove println call when flipping state changed

### DIFF
--- a/flippable/src/main/java/com/wajahatkarim/flippable/Flippable.kt
+++ b/flippable/src/main/java/com/wajahatkarim/flippable/Flippable.kt
@@ -122,7 +122,6 @@ fun Flippable(
     LaunchedEffect(key1 = flipController, block = {
         flipController.flipRequests
             .onEach {
-                println("Flip Controller $it")
                 flippableState = it
             }
             .launchIn(this)


### PR DESCRIPTION
I propose to remove this line:

 `println("Flip Controller $it")` 

This is some debug information that might not be interesting to keep in production.