### PR TITLE
Add initialSide parameter and list demo

### DIFF
--- a/app/src/main/java/com/wajahatkarim/flippable_demo/FlippableListDemo.kt
+++ b/app/src/main/java/com/wajahatkarim/flippable_demo/FlippableListDemo.kt
@@ -1,0 +1,212 @@
+package com.wajahatkarim.flippable_demo
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.runtime.toMutableStateList
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.wajahatkarim.flippable.FlipAnimationType
+import com.wajahatkarim.flippable.Flippable
+import com.wajahatkarim.flippable.FlippableController
+import com.wajahatkarim.flippable.FlippableState
+
+data class WordCard(
+    val id: Int,
+    val word: String,
+    val partOfSpeech: String,
+    val definition: String,
+    val example: String,
+    val accentColor: Color,
+)
+
+val sampleCards = listOf(
+    WordCard(0, "Ephemeral", "adj.", "Lasting for a very short time", "Social media fame is often ephemeral.", Color(0xFF6200EE)),
+    WordCard(1, "Serendipity", "n.", "The occurrence of happy accidents", "It was pure serendipity that they met.", Color(0xFF0097A7)),
+    WordCard(2, "Eloquent", "adj.", "Fluent or persuasive in speaking or writing", "She gave an eloquent speech at the ceremony.", Color(0xFF388E3C)),
+    WordCard(3, "Pragmatic", "adj.", "Dealing with things sensibly and practically", "A pragmatic approach to problem solving.", Color(0xFFE64A19)),
+    WordCard(4, "Resilient", "adj.", "Able to recover quickly from difficulties", "Children are surprisingly resilient.", Color(0xFF7B1FA2)),
+    WordCard(5, "Meticulous", "adj.", "Showing great attention to detail", "She was meticulous in her research.", Color(0xFF0288D1)),
+    WordCard(6, "Tenacious", "adj.", "Holding firmly to a purpose or goal", "His tenacious spirit eventually led to success.", Color(0xFFC62828)),
+    WordCard(7, "Ambiguous", "adj.", "Open to more than one interpretation", "The exam question was frustratingly ambiguous.", Color(0xFF4E342E)),
+    WordCard(8, "Candid", "adj.", "Truthful and straightforward", "I really appreciated her candid feedback.", Color(0xFF00695C)),
+    WordCard(9, "Profound", "adj.", "Having deep insight or great intensity", "A profound silence filled the room.", Color(0xFF37474F)),
+)
+
+@Composable
+fun FlippableListScreen() {
+    val controllers = remember { sampleCards.map { FlippableController() } }
+    val flipStates: SnapshotStateList<Boolean> = remember {
+        sampleCards.map { false }.toMutableStateList()
+    }
+    var isAllFlipped by remember { mutableStateOf(false) }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        Button(
+            onClick = {
+                isAllFlipped = !isAllFlipped
+                flipStates.indices.forEach { i -> flipStates[i] = isAllFlipped }
+                controllers.forEach { controller ->
+                    if (isAllFlipped) controller.flipToBack() else controller.flipToFront()
+                }
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            shape = RoundedCornerShape(12.dp),
+            colors = ButtonDefaults.buttonColors(
+                backgroundColor = if (isAllFlipped) Color(0xFF424242) else MaterialTheme.colors.primary
+            )
+        ) {
+            Text(
+                text = if (isAllFlipped) "Hide All Answers" else "Reveal All Answers",
+                style = MaterialTheme.typography.button,
+                color = Color.White,
+                modifier = Modifier.padding(vertical = 4.dp)
+            )
+        }
+
+        LazyColumn(
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(bottom = 12.dp)
+        ) {
+            itemsIndexed(items = sampleCards, key = { _, card -> card.id }) { index, card ->
+                Flippable(
+                    frontSide = { WordCardFront(card) },
+                    backSide = { WordCardBack(card) },
+                    flipController = controllers[index],
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
+                    initialSide = if (flipStates[index]) FlippableState.BACK else FlippableState.FRONT,
+                    flipAnimationType = FlipAnimationType.VERTICAL_CLOCKWISE,
+                    onFlippedListener = { side ->
+                        flipStates[index] = (side == FlippableState.BACK)
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun WordCardFront(card: WordCard) {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(120.dp),
+        shape = RoundedCornerShape(16.dp),
+        color = Color(0xFFF5F5F5),
+        elevation = 4.dp
+    ) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 20.dp, vertical = 16.dp),
+                verticalArrangement = Arrangement.Center
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = card.word,
+                        style = MaterialTheme.typography.h6,
+                        fontWeight = FontWeight.Bold,
+                        color = Color(0xFF212121)
+                    )
+                    Spacer(modifier = Modifier.weight(1f))
+                    Text(
+                        text = card.partOfSpeech,
+                        style = MaterialTheme.typography.caption,
+                        color = Color(0xFF9E9E9E),
+                        fontStyle = FontStyle.Italic
+                    )
+                }
+            }
+            Text(
+                text = "TAP TO SEE DEFINITION",
+                style = MaterialTheme.typography.overline,
+                color = Color(0xFFBDBDBD),
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 10.dp)
+            )
+        }
+    }
+}
+
+@Composable
+fun WordCardBack(card: WordCard) {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(120.dp),
+        shape = RoundedCornerShape(16.dp),
+        elevation = 4.dp
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(color = card.accentColor, shape = RoundedCornerShape(16.dp))
+                .padding(horizontal = 20.dp, vertical = 14.dp)
+        ) {
+            Column(modifier = Modifier.fillMaxSize()) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = card.word,
+                        style = MaterialTheme.typography.subtitle1,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.White.copy(alpha = 0.7f)
+                    )
+                    Spacer(modifier = Modifier.weight(1f))
+                    Text(
+                        text = card.partOfSpeech,
+                        style = MaterialTheme.typography.caption,
+                        color = Color.White.copy(alpha = 0.5f),
+                        fontStyle = FontStyle.Italic
+                    )
+                }
+                Spacer(modifier = Modifier.height(6.dp))
+                Text(
+                    text = card.definition,
+                    style = MaterialTheme.typography.body2,
+                    fontWeight = FontWeight.Medium,
+                    color = Color.White
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "\"${card.example}\"",
+                    style = MaterialTheme.typography.caption,
+                    color = Color.White.copy(alpha = 0.75f),
+                    fontStyle = FontStyle.Italic
+                )
+            }
+        }
+    }
+}

--- a/flippable/src/main/java/com/wajahatkarim/flippable/Flippable.kt
+++ b/flippable/src/main/java/com/wajahatkarim/flippable/Flippable.kt
@@ -72,7 +72,7 @@ enum class FlipAnimationType {
  *      },
  *      backSide = {
  *          // Composable content
- *      }),
+ *      },
  *      flipController = rememberFlipController(),
  *      // ... other optional parameters
  *  ```
@@ -81,6 +81,10 @@ enum class FlipAnimationType {
  *  @param backSide [Composable] method to draw any view for the back side
  *  @param flipController A [FlippableController] which lets you control flipping programmatically.
  *  @param modifier The Modifier for this [Flippable]
+ *  @param initialSide The initial side to display when the [Flippable] first appears.
+ *  Defaults to [FlippableState.FRONT]. Pass [FlippableState.BACK] to start with the back side
+ *  visible — useful when restoring flip state across list items or navigation.
+ *  Must not be [FlippableState.INITIALIZED].
  *  @param contentAlignment The [Flippable] is contained in a [Box], so this tells the alignment to organize both Front and Back side composable.
  *  @param flipDurationMs The duration in Milliseconds for the flipping animation
  *  @param flipOnTouch If true, flipping will be done through clicking the Front/Back sides.
@@ -88,7 +92,9 @@ enum class FlipAnimationType {
  *  @param autoFlip If true, the [Flippable] will automatically flip back after [autoFlipDurationMs].
  *  @param autoFlipDurationMs The duration in Milliseconds to auto-flip back
  *  @param cameraDistance The [GraphicsLayerScope.cameraDistance] for the flip animation. Sets the distance along the Z axis (orthogonal to the X/Y plane on which layers are drawn) from the camera to this layer.
- *  @param flipAnimationType The animation type of flipping effect.
+ *  @param flipAnimationType The animation direction of the flip effect. Use [FlipAnimationType.HORIZONTAL_CLOCKWISE]
+ *  or [FlipAnimationType.HORIZONTAL_ANTI_CLOCKWISE] for left/right flips, and
+ *  [FlipAnimationType.VERTICAL_CLOCKWISE] or [FlipAnimationType.VERTICAL_ANTI_CLOCKWISE] for up/down flips.
  *  @param onFlippedListener The listener which is triggered when flipping animation is finished.
  *
  *  @author Wajahat Karim (https://wajahatkarim.com)
@@ -99,6 +105,7 @@ fun Flippable(
     backSide: @Composable () -> Unit,
     flipController: FlippableController,
     modifier: Modifier = Modifier,
+    initialSide: FlippableState = FlippableState.FRONT,
     contentAlignment: Alignment = Alignment.Center,
     flipDurationMs: Int = 400,
     flipOnTouch: Boolean = true,
@@ -107,8 +114,12 @@ fun Flippable(
     autoFlipDurationMs: Int = 1000,
     cameraDistance: Float = 30.0F,
     flipAnimationType: FlipAnimationType = FlipAnimationType.HORIZONTAL_CLOCKWISE,
-    onFlippedListener: (currentSide: FlippableState) -> Unit = { _, -> }
+    onFlippedListener: (currentSide: FlippableState) -> Unit = { _ -> }
 ) {
+    require(initialSide != FlippableState.INITIALIZED) {
+        "initialSide must be FRONT or BACK, not INITIALIZED."
+    }
+
     var prevViewState by remember { mutableStateOf(FlippableState.INITIALIZED) }
     var flippableState by remember { mutableStateOf(FlippableState.INITIALIZED) }
     val transition: Transition<FlippableState> = updateTransition(
@@ -129,7 +140,7 @@ fun Flippable(
     })
 
     val flipCall: () -> Unit = {
-        if (transition.isRunning.not() && flipEnabled) {
+        if (transition.isRunning.not() && flipEnabled && flippableState != FlippableState.INITIALIZED) {
             prevViewState = flippableState
             if (flippableState == FlippableState.FRONT)
                 flipController.flipToBack()
@@ -142,7 +153,8 @@ fun Flippable(
     LaunchedEffect(key1 = transition.currentState, block = {
         if (transition.currentState == FlippableState.INITIALIZED) {
             prevViewState = FlippableState.INITIALIZED
-            flippableState = FlippableState.FRONT
+            flippableState = initialSide
+            flipController.setCurrentSide(initialSide)
             return@LaunchedEffect
         }
 
@@ -184,7 +196,7 @@ fun Flippable(
         },
         label = "Front Rotation"
     ) { state ->
-        when(state) {
+        when (state) {
             FlippableState.INITIALIZED, FlippableState.FRONT -> 0f
             FlippableState.BACK -> 180f
         }
@@ -216,7 +228,7 @@ fun Flippable(
         },
         label = "Back Rotation"
     ) { state ->
-        when(state) {
+        when (state) {
             FlippableState.INITIALIZED, FlippableState.FRONT -> 180f
             FlippableState.BACK -> 0f
         }
@@ -250,7 +262,7 @@ fun Flippable(
         },
         label = "Front Opacity"
     ) { state ->
-        when(state) {
+        when (state) {
             FlippableState.INITIALIZED, FlippableState.FRONT -> 1f
             FlippableState.BACK -> 0f
         }
@@ -284,7 +296,7 @@ fun Flippable(
         },
         label = "Back Opacity"
     ) { state ->
-        when(state) {
+        when (state) {
             FlippableState.INITIALIZED, FlippableState.FRONT -> 0f
             FlippableState.BACK -> 1f
         }
@@ -330,7 +342,7 @@ fun Flippable(
                 }
             }
             .alpha(frontOpacity)
-            .zIndex(1F - frontRotation)
+            .zIndex(1F - frontOpacity)
         ) {
             frontSide()
         }

--- a/flippable/src/main/java/com/wajahatkarim/flippable/FlippableController.kt
+++ b/flippable/src/main/java/com/wajahatkarim/flippable/FlippableController.kt
@@ -19,6 +19,14 @@ class FlippableController {
     private var _flipEnabled: Boolean = true
 
     /**
+     * Updates the internally tracked current side without triggering a flip animation.
+     * Used by [Flippable] to sync the controller with [Flippable.initialSide] on initialization.
+     */
+    internal fun setCurrentSide(side: FlippableState) {
+        _currentSide = side
+    }
+
+    /**
      * Flips the view to the [FlippableState.FRONT] side
      */
     fun flipToFront() {


### PR DESCRIPTION
##  Motivation

When using Flippable in a list (e.g. LazyColumn), items that scroll off screen lose their composition state. Without a way to set the starting side, every card always re-appears showing the front — making it impossible to restore flip state across list items.

## Changes

Flippable.kt
- Add initialSide: FlippableState parameter (defaults to FRONT) — pass BACK to
start with the back side visible
- Guard flipCall against INITIALIZED state to prevent a race condition on fast
taps
- Normalize rotation signs so FlipAnimationType enum values are semantically
correct (CLOCKWISE / ANTI_CLOCKWISE behave as named)

FlippableController.kt
- Add internal setCurrentSide() to sync the controller's tracked state with
initialSide on initialization — fixes flipController.flip() toggling in the
wrong direction when starting from BACK

## Demo app
- Add a LazyColumn list demo with 10 vocabulary flash cards
- Each card tracks its own flip state; scrolling away and back restores the
correct side via initialSide
- "Reveal All Answers" / "Hide All Answers" button flips all cards at once

### Demo
[Screen_recording_20260317_231731.webm](https://github.com/user-attachments/assets/24cd12ff-b05c-4886-93f3-d3575eadda9d)

## Usage

```kotlin
  // Start with back side visible (e.g. already-answered card in a list)
  Flippable(
      frontSide = { ... },
      backSide = { ... },
      flipController = rememberFlipController(),
      initialSide = FlippableState.BACK
  )
```